### PR TITLE
Add OtherTaggedUnion type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,11 @@ type MatchConfiguration<DefObj extends DefObjSuper> =
       DefObj
     >;
 
+// this type works by "extracting" the generic type from a TaggedUnion (see
+// https://stackoverflow.com/questions/44851268/typescript-how-to-extract-the-generic-parameter-from-a-type)
+// and rewrapping it in MemberObject, which is the type of tagged union instances
+export type OtherTaggedUnion<Type> = MemberObject<Type extends TaggedUnion<infer X> ? X : never>;
+
 class MemberObjectImpl {
   variant: any;
   data: any;


### PR DESCRIPTION
This allows a tagged union to use another tagged union as a type. I'm not sure if this is necessarily the cleanest way to do it, or whether `OtherTaggedUnion` is a good title. A proposed solution to #13.